### PR TITLE
[기능] 헤더에서 선호하는 팀의 대시보드 페이지로 이동하는 기능 구현

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,32 +2,56 @@ import React from 'react';
 import { Button } from '../common/Button';
 import { Link, useNavigate } from 'react-router-dom';
 import { useUserStore } from '../../store/store';
+import { teamNameToKey } from '../../utils/team/team-name-map';
 
 function Header() {
   const navigate = useNavigate();
   const user = useUserStore((state) => state.user);
 
-  
+  const handleTeamInfoClick = () => {
+    if (user && user.favoriteTeam) {
+      const teamSlug =
+        teamNameToKey[user.favoriteTeam as keyof typeof teamNameToKey];
+
+      if (teamSlug) {
+        navigate(`/teams/${teamSlug}`);
+      } else {
+        alert('팀 정보를 불러오지 못했습니다.');
+      }
+    } else {
+      alert('팀 정보를 불러오지 못했습니다.');
+    }
+  };
+
   return (
     <header className="bg-white">
       <nav className="container mx-auto px-5 py-5">
         <div className="flex items-center justify-between">
-          <div className="text-2xl font-medium text-gray-900">
-            <a href="/">My KBO</a>
+          <div className="text-2xl font-bold text-kbo-blue">
+            <Link to="/">My KBO</Link>
           </div>
 
-
-          <div className="flex items-center gap-10 md:flex items-center ">
-            <a href="/" className="text-gray-900">
+          <div className="flex items-center gap-10">
+            <Link
+              to="/"
+              className="text-gray-900 hover:text-kbo-light-blue transition-colors"
+            >
               홈
-            </a>
-            <a href="/team-info" className="text-gray-900 ">
-              팀 정보
-            </a>
-            <Link to="/board" className="text-gray-900">
+            </Link>
+            {user && (
+              <button
+                onClick={handleTeamInfoClick}
+                className="text-gray-900 hover:text-kbo-light-blue transition-colors"
+              >
+                팀 대시보드
+              </button>
+            )}
+            <Link
+              to="/board"
+              className="text-gray-900 hover:text-kbo-light-blue transition-colors"
+            >
               커뮤니티
             </Link>
-
 
             {user ? (
               <Button

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
         gray800: '#26282b',
         gray900: '#1b1d1f',
         'kbo-blue': '#002561',
-        'kbo-lightblue': '#00AEEf',
+        'kbo-light-blue': '#00AEEf',
         'kbo-red': '#ed1c24',
       },
     },


### PR DESCRIPTION
### 작업 내용
- tailwind.config.js에서 kbo-light-blue 색상 이름 변경
- 로그인을 하지 않았을땐 헤더에 '팀 대시보드' 버튼 보이지 않게 함
- 로그인 후 '팀 대시보드' 버튼 클릭시 선호하는 팀의 대시보드 페이지로 이동

### 참고사항
- 브랜치는 실수했습니다 ^^