### PR TITLE
[수정] 선호하는 팀을 수정해도 헤더에서 해당 팀 대시보드 페이지로 이동할 수 있게 수정

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,8 +10,8 @@ function Header() {
 
   const handleTeamInfoClick = () => {
     if (user && user.favoriteTeam) {
-      const teamSlug =
-        teamNameToKey[user.favoriteTeam as keyof typeof teamNameToKey];
+      const teamName = user.favoriteTeam.split(' ')[0];
+      const teamSlug = teamNameToKey[teamName as keyof typeof teamNameToKey];
 
       if (teamSlug) {
         navigate(`/teams/${teamSlug}`);


### PR DESCRIPTION
### 작업내용
- 공백을 기준으로 첫번째 문자열만 추출
- 해당 문자열의 팀의 대시보드로 이동